### PR TITLE
Add ProductFactory PHPUnit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# MerchandiseCentral
+
+## Running backend tests
+
+Use Composer's vendor binary for PHPUnit:
+
+```
+cd backend
+vendor/bin/phpunit
+```
+

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -3,5 +3,8 @@
         "vlucas/phpdotenv": "^5.5",
         "ext-mbstring": "*",
         "ext-xml": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.0"
     }
 }

--- a/backend/tests/ProductFactoryTest.php
+++ b/backend/tests/ProductFactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+require_once __DIR__ . '/../classes/ProductFactory.php';
+require_once __DIR__ . '/../classes/product/DVD.php';
+require_once __DIR__ . '/../classes/product/Book.php';
+require_once __DIR__ . '/../classes/product/Furniture.php';
+
+use PHPUnit\Framework\TestCase;
+
+class ProductFactoryTest extends TestCase
+{
+    public function testCreateDVD()
+    {
+        $db = $this->createMock(PDO::class);
+        $product = ProductFactory::createProduct('DVD', $db);
+        $this->assertInstanceOf(DVD::class, $product);
+    }
+
+    public function testCreateBook()
+    {
+        $db = $this->createMock(PDO::class);
+        $product = ProductFactory::createProduct('Book', $db);
+        $this->assertInstanceOf(Book::class, $product);
+    }
+
+    public function testCreateFurniture()
+    {
+        $db = $this->createMock(PDO::class);
+        $product = ProductFactory::createProduct('Furniture', $db);
+        $this->assertInstanceOf(Furniture::class, $product);
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit dev dependency
- provide ProductFactoryTest covering object creation
- document how to run PHPUnit in README

## Testing
- `vendor/bin/phpunit tests/ProductFactoryTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6873097572208328856b4c4125f9f59f