### PR TITLE
Fix product factory mapping

### DIFF
--- a/backend/classes/ProductFactory.php
+++ b/backend/classes/ProductFactory.php
@@ -9,19 +9,20 @@ class ProductFactory
 {
     public static function createProduct($productType, $db)
     {
-        $product = null;
+        $classMap = [
+            'dvd' => 'DVD',
+            'book' => 'Book',
+            'furniture' => 'Furniture'
+        ];
 
-        $productClass = strtoupper($productType);
-        // 👇 this is a debug line i used to display the product class
-        /* echo "Product class: " . $productClass . PHP_EOL; */
-        if (class_exists($productClass)) {
-            $product = new $productClass($db);
-        }
+        $key = strtolower($productType);
 
-        if ($product === null) {
+        if (!isset($classMap[$key]) || !class_exists($classMap[$key])) {
             throw new Exception("Invalid product type: {$productType}");
         }
 
-        return $product;
+        $productClass = $classMap[$key];
+
+        return new $productClass($db);
     }
 }


### PR DESCRIPTION
## Summary
- fix ProductFactory to map product types to class names without capitalization issues

## Testing
- `php -l backend/classes/ProductFactory.php`

------
https://chatgpt.com/codex/tasks/task_e_6872c59dc3d48328b6b74d853401be92